### PR TITLE
misc changes to readme and usage messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BraidDatTool
 
-Usage: BraidDatTool [-u archive_name | -r archive_name [compression_level]]
+Usage: BraidDatTool (-u archive_name | -r archive_name [compression_level])
 
 ```
 	 -u archive_name                            Unpack the archive. 
@@ -11,4 +11,4 @@ When repacking, optionally you can specify the compression level. Valid values a
 
 Default value is 6 (devs used it), but it's pretty slow, very slow I would say, so I decided to add this compression level option at least for testing purposes.
 
-Looking for the archive to run BraidDatTool on? Maybe it's `C:\Program Files (x86)\Steam\steamapps\common\Braid Anniversary Edition\data\data.dat`, or in a similar location.
+Looking for the archive to run BraidDatTool on? Maybe it's `C:\Program Files (x86)\Steam\steamapps\common\Braid Anniversary Edition\data\braid.dat`, or in a similar location. Typically the folder where the Braid executable lives has a subfolder data/, which includes only the archive file, braid.dat.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ When repacking, optionally you can specify the compression level. Valid values a
 Default value is 6 (devs used it), but it's pretty slow, very slow I would say, so I decided to add this compression level option at least for testing purposes.
 
 Looking for the archive to run BraidDatTool on? Maybe it's `C:\Program Files (x86)\Steam\steamapps\common\Braid Anniversary Edition\data\braid.dat`, or in a similar location. Typically the folder where the Braid executable lives has a subfolder data/, which includes only the archive file, braid.dat.
+
+TODO: currently, the archive_name parameter is ignored, and braid.dat or braid.dat_new (respectively) is hard-coded instead.

--- a/main.go
+++ b/main.go
@@ -5,21 +5,21 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 )
+
+import _ "embed"
 
 const (
 	dat_magic     = "BRAID-BF"
 	threadsUnpack = 16
 	threadsPack   = 16
 )
+//go:embed README.md
+var readme string
 
 func die_with_usage_message() {
-	fmt.Printf("Usage: BraidDatTool [-u archive_name | -r archive_name [compression_level]]\n")
-	fmt.Printf("\t -u archive_name                            Unpack the archive. \n")
-	fmt.Printf("\t -r archive_name [compression_level]        Repack the archive. \n")
-	fmt.Printf("When repacking, optionally you can specify the compression level. Valid values are from -4 (fastest) to 9 (slowest).\n")
-	fmt.Printf("Default value is 6 (devs used it), but it's pretty slow, very slow I would say, so I decided to add this compression level option at least for testing purposes.\n")
-	fmt.Printf("Looking for the archive to run BraidDatTool on? Maybe it's \"C:\\Program Files (x86)\\Steam\\steamapps\\common\\Braid Anniversary Edition\\data\\data.dat\" or in a similar location.\n")
+	fmt.Printf(strings.Join(strings.Split(readme, "\n")[2:], "\n"))
 	log.Fatal()
 }
 
@@ -50,15 +50,15 @@ func main() {
 		if len(args) > 3 {
 			value, _ := strconv.Atoi(args[3])
 			if value >= -4 && value <= 9 {
-				fmt.Printf("Compression level value is set to %v\n\n", value)
+				fmt.Printf("Compression level value is set to %v.\n\n", value)
 				Repack(value, threadsPack)
 			} else {
-				fmt.Printf("Invalid compression level value. Value will be set to 6\n\n")
+				fmt.Printf("Invalid compression level value. Value will be set to 6.\n\n")
 				value = 6
 				Repack(value, threadsPack)
 			}
 		} else {
-			fmt.Printf("Compression level value is not specified. Value will be set to 6\n\n")
+			fmt.Printf("Compression level value is not specified. Value will be set to 6.\n\n")
 			value := 6
 			Repack(value, threadsPack)
 		}


### PR DESCRIPTION
This commit adds some more relevant/updated info to the readme, and also single-sources the cli usage info message from the readme.

Oh, also, since one of the two arguments is mandatory, (|) is correct instead of [|].

Also, I added some periods to the end of some sentences.

Note that there are now ```s in the cli usage output message, because it didn't seem worth it to remove them.